### PR TITLE
examples: Remove double-backslash from install path

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -120,7 +120,7 @@ if(BUILDEXAMPLES)
 
     # Add all examples as an install component (if building examples)
     install (DIRECTORY ${PROJECT_SOURCE_DIR}/examples
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/upm/
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/upm
         COMPONENT ${CMAKE_PROJECT_NAME}-examples
         FILES_MATCHING
             PATTERN "*.c"


### PR DESCRIPTION
This commit removes the double-backslash when installing the examples.

Before:
   .../upm//examples/...

Before:
   .../upm/examples/...

Signed-off-by: Noel Eck <noel.eck@intel.com>